### PR TITLE
add libudev-dev to linux dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Please ensure [Python 2.7 is installed](https://www.python.org/downloads/) for a
 
  * Kernel version 3.6 or above
  * ```libbluetooth-dev```
+ * ```libudev-dev```
 
 ### Windows 8+
 


### PR DESCRIPTION
Without `libudev-dev` installed I get the following from `npm install`

```
../libusb/libusb/os/linux_udev.c:40:21: fatal error: libudev.h: No such file or directory
compilation terminated.
libusb.target.mk:133: recipe for target 'Release/obj.target/libusb/libusb/libusb/os/linux_udev.o' failed
make: *** [Release/obj.target/libusb/libusb/libusb/os/linux_udev.o] Error 1
make: Leaving directory '/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:194:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Linux 4.4.0-78-generic
gyp ERR! command "/usr/bin/nodejs" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/src/binding/usb_bindings.node" "--module_name=usb_bindings" "--module_path=/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/src/binding"
gyp ERR! cwd /home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb
gyp ERR! node -v v7.10.0
gyp ERR! node-gyp -v v3.5.0
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/usr/bin/nodejs /usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/src/binding/usb_bindings.node --module_name=usb_bindings --module_path=/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/src/binding' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:106:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:194:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:899:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
node-pre-gyp ERR! System Linux 4.4.0-78-generic
node-pre-gyp ERR! command "/usr/bin/nodejs" "/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb
node-pre-gyp ERR! node -v v7.10.0
node-pre-gyp ERR! node-pre-gyp -v v0.6.30
node-pre-gyp ERR! not ok 
Failed to execute '/usr/bin/nodejs /usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/src/binding/usb_bindings.node --module_name=usb_bindings --module_path=/home/ben/projects/OpenBCI_NodeJS_Ganglion/node_modules/usb/src/binding' (1)```