### PR TITLE
FIX: error where bled112 port name change could break driver

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v1.1.6
+
+### Bug Fixes
+
+* BLED112 port name can change so made dynamic port finding routine and error message when no mattching driver found.
+
 # v1.1.5
 
 Chore bump noble version to v1.9.0 for macOS High Sierra 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-ganglion",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "The official Node.js SDK for the OpenBCI Ganglion Biosensor Board.",
   "main": "openBCIGanglion.js",
   "scripts": {


### PR DESCRIPTION
# v1.1.6

### Bug Fixes

* BLED112 port name can change so made dynamic port finding routine and error message when no mattching driver found.
